### PR TITLE
Couple of fixes

### DIFF
--- a/Sources/RollingNumbers/CharLayer.swift
+++ b/Sources/RollingNumbers/CharLayer.swift
@@ -38,7 +38,7 @@ final class CharLayer: CATextLayer {
         alignmentMode = .center
         isWrapped = true
 
-        // It’s perfect for objects that animate around the screen but don’t change in appearance
-        shouldRasterize = true
+        shouldRasterize = false
+		contentsScale = UIScreen.main.scale
     }
 }

--- a/Sources/RollingNumbers/DigitLayer.swift
+++ b/Sources/RollingNumbers/DigitLayer.swift
@@ -51,7 +51,7 @@ final class DigitLayer: CATextLayer {
         alignmentMode = .center
         isWrapped = true
 
-        // It’s perfect for objects that animate around the screen but don’t change in appearance
-        shouldRasterize = true
+		shouldRasterize = false
+		contentsScale = UIScreen.main.scale
     }
 }

--- a/Sources/RollingNumbers/RollingNumbers.swift
+++ b/Sources/RollingNumbers/RollingNumbers.swift
@@ -181,12 +181,19 @@ public final class RollingNumbersView: UIView {
     public var height: CGFloat {
         frame.height
     }
-    
+	
     public override func layoutSubviews() {
         super.layoutSubviews()
+		
+		if bounds != lastBounds {
+			isInitialColumnsPrepared = false
+			lastBounds = bounds
+		}
         
-        prepareColumns()
-        isInitialColumnsPrepared = true
+		if !isInitialColumnsPrepared {
+			prepareColumns()
+			isInitialColumnsPrepared = true
+		}
     }
     
     required init?(coder: NSCoder) {
@@ -201,6 +208,7 @@ public final class RollingNumbersView: UIView {
     private var currDigits: [Int] = []
     private var prevDigits: [Int] = []
     private var isSubtraсted: Bool = false
+	private var lastBounds: CGRect = .zero
 
     private(set) var number: Double {
         didSet(prev) {

--- a/Sources/RollingNumbers/RollingNumbers.swift
+++ b/Sources/RollingNumbers/RollingNumbers.swift
@@ -185,10 +185,8 @@ public final class RollingNumbersView: UIView {
     public override func layoutSubviews() {
         super.layoutSubviews()
         
-        if !isInitialColumnsPrepared {
-            prepareColumns()
-            isInitialColumnsPrepared = true
-        }
+        prepareColumns()
+        isInitialColumnsPrepared = true
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
(1) when `UIView` that containing the digits layer changes size, sublayers need to recreated. I'm not sure what's the exact optimization that `isInitialColumnsPrepared` is bringing so did not remove it but removing that `if` check solves the issue.

(2) `shouldRasterize=true` may be more optimal but it's detrimental to rendering quality thus removed it. With added nativeScale setup, it renders perfect digits.